### PR TITLE
Add richer clap args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -281,6 +281,7 @@ fn main() {
             .takes_value(true)
             .value_name("PATH")
             .default_value(default_config_file)
+            .global(true)
             .help("config file to use")
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use {
     solana_cli_config::{Config, ConfigInput, CONFIG_FILE},
     solana_client::{client_error, rpc_client::RpcClient},
     solana_sdk::{
-        commitment_config::CommitmentConfig,
         instruction::{AccountMeta, Instruction},
         message::Message,
         pubkey,
@@ -407,7 +406,11 @@ fn main() {
         arg_matches.value_of("json_rpc_url").unwrap_or(""),
         &cli_config.json_rpc_url,
     );
-    let commitment = CommitmentConfig::from_str(&cli_config.commitment).unwrap_or_default();
+
+    let (_, commitment) = ConfigInput::compute_commitment_config(
+        arg_matches.value_of("commitment").unwrap_or(""),
+        &cli_config.commitment,
+    );
 
     let (_, default_signer_path) = ConfigInput::compute_keypair_path_setting(
         arg_matches.value_of("keypair").unwrap_or(""),

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,8 +297,10 @@ fn main() {
                 ),
         )
         .arg(clap::Arg::with_name("keypair")
+            .short("k")
             .long("keypair")
             .takes_value(true)
+            .global(true)
             .value_name("SIGNER")
             .help("default signer")
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,7 +377,8 @@ fn main() {
         clap::value_t!(arg_matches, "keypair", String).unwrap_or(cli_config.keypair_path);
     let default_signer = DefaultSigner::new("keypair", keypair_path);
     //let rpc_client = RpcClient::new("https://api.devnet.solana.com");
-    let rpc_client = RpcClient::new("https://api.mainnet-beta.solana.com");
+    let rpc_client =
+        RpcClient::new_with_commitment("https://api.mainnet-beta.solana.com", commitment);
     let (fee_payer_key, fee_payer_pubkey) = (None, Option::<Pubkey>::None);
     let mut bulk_signers = vec![fee_payer_key];
     let mut wallet_manager = None;
@@ -533,9 +534,7 @@ fn main() {
         .pubkey();
         let message = Message::new(&ix_batch, Some(&fee_payer_pubkey));
 
-        let (recent_blockhash, _) = rpc_client
-            .get_latest_blockhash_with_commitment(commitment)
-            .expect("recent blockhash");
+        let recent_blockhash = rpc_client.get_latest_blockhash().expect("recent blockhash");
         let signers = signer_info.signers_for_message(&message);
         let transaction = Transaction::new(&signers, message, recent_blockhash);
         let tx_id = rpc_client

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use {
     borsh::{BorshDeserialize, BorshSerialize},
-    clap::{value_t, value_t_or_exit},
+    clap::value_t_or_exit,
     solana_clap_utils::{
         input_parsers::*,
         input_validators::*,
@@ -392,9 +392,12 @@ fn main() {
         &cli_config.json_rpc_url,
     );
     let commitment = CommitmentConfig::from_str(&cli_config.commitment).unwrap_or_default();
-    let keypair_path =
-        clap::value_t!(arg_matches, "keypair", String).unwrap_or(cli_config.keypair_path);
-    let default_signer = DefaultSigner::new("keypair", keypair_path);
+
+    let (_, default_signer_path) = ConfigInput::compute_keypair_path_setting(
+        arg_matches.value_of("keypair").unwrap_or(""),
+        &cli_config.keypair_path,
+    );
+    let default_signer = DefaultSigner::new("keypair", default_signer_path);
 
     let rpc_client = RpcClient::new_with_commitment(json_rpc_url, commitment);
     let (fee_payer_key, fee_payer_pubkey) = (None, Option::<Pubkey>::None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,22 @@ fn main() {
             .value_name("SIGNER")
             .help("default signer")
         )
+        .arg(
+            clap::Arg::with_name("commitment")
+                .long("commitment")
+                .takes_value(true)
+                .possible_values(&[
+                    "processed",
+                    "confirmed",
+                    "finalized",
+                ])
+                .value_name("COMMITMENT_LEVEL")
+                .global(true)
+                .help(
+                    "Return information at the selected commitment level \
+                    [possible values: processed, confirmed, finalized]",
+                ),
+        )
         .subcommand(clap::SubCommand::with_name("multisig-create")
             .arg(clap::Arg::with_name("threshold")
                 .index(1)


### PR DESCRIPTION
This adds support for:
- `--url/-u`, with monikers
- the short `-k` for keypair
- `--commitment`
- `--fee-payer`

Needs rebase on:
- [x] #1 
- [ ] #2 